### PR TITLE
Add missing READMEs

### DIFF
--- a/Payload-Encryption/AES/README.md
+++ b/Payload-Encryption/AES/README.md
@@ -1,0 +1,7 @@
+# AES Encryption
+
+This directory collects three AES implementations used to encrypt payloads.
+
+- `TinyAES` – uses the tiny-AES-c library.
+- `bCryptAES` – uses Windows BCrypt API.
+- `stdAES` – uses Zig's standard library crypto implementation.

--- a/Payload-Encryption/RC4/README.md
+++ b/Payload-Encryption/RC4/README.md
@@ -1,0 +1,3 @@
+# RC4 Encryption
+
+Demonstrates encrypting a payload with the RC4 stream cipher. Build the project with `zig build`.

--- a/Payload-Encryption/XOR/README.md
+++ b/Payload-Encryption/XOR/README.md
@@ -1,0 +1,3 @@
+# XOR Encryption
+
+A minimal example of XORing a payload for simple obfuscation. Compile with `zig build`.

--- a/Payload-Obfuscation/IP-Address-Obfuscation/IPv4Deobfuscation/README.md
+++ b/Payload-Obfuscation/IP-Address-Obfuscation/IPv4Deobfuscation/README.md
@@ -1,0 +1,3 @@
+# IPv4 Deobfuscation
+
+Companion code for reversing the IPv4 obfuscation routine.

--- a/Payload-Obfuscation/IP-Address-Obfuscation/IPv4Fuscation/README.md
+++ b/Payload-Obfuscation/IP-Address-Obfuscation/IPv4Fuscation/README.md
@@ -1,0 +1,3 @@
+# IPv4 Obfuscation
+
+Example showing how to transform an IPv4 address into an obfuscated form.

--- a/Payload-Obfuscation/IP-Address-Obfuscation/IPv6Deobfuscation/README.md
+++ b/Payload-Obfuscation/IP-Address-Obfuscation/IPv6Deobfuscation/README.md
@@ -1,0 +1,3 @@
+# IPv6 Deobfuscation
+
+Reverses the IPv6 obfuscation process to obtain the original address.

--- a/Payload-Obfuscation/IP-Address-Obfuscation/IPv6Fuscation/README.md
+++ b/Payload-Obfuscation/IP-Address-Obfuscation/IPv6Fuscation/README.md
@@ -1,0 +1,3 @@
+# IPv6 Obfuscation
+
+Transforms an IPv6 address into an obfuscated representation.

--- a/Payload-Obfuscation/IP-Address-Obfuscation/README.md
+++ b/Payload-Obfuscation/IP-Address-Obfuscation/README.md
@@ -1,0 +1,3 @@
+# IP Address Obfuscation
+
+Utilities to hide or restore IPv4 and IPv6 addresses. See the subdirectories for specific implementations.

--- a/Payload-Obfuscation/MAC-Address-Obfuscation/MACDeobfuscation/README.md
+++ b/Payload-Obfuscation/MAC-Address-Obfuscation/MACDeobfuscation/README.md
@@ -1,0 +1,3 @@
+# MAC Address Deobfuscation
+
+Restores the original MAC address from the obfuscated form.

--- a/Payload-Obfuscation/MAC-Address-Obfuscation/MACFuscation/README.md
+++ b/Payload-Obfuscation/MAC-Address-Obfuscation/MACFuscation/README.md
@@ -1,0 +1,3 @@
+# MAC Address Obfuscation
+
+Implements a routine to hide a MAC address.

--- a/Payload-Obfuscation/MAC-Address-Obfuscation/README.md
+++ b/Payload-Obfuscation/MAC-Address-Obfuscation/README.md
@@ -1,0 +1,3 @@
+# MAC Address Obfuscation
+
+Tools to obfuscate or deobfuscate MAC addresses.

--- a/Payload-Obfuscation/README.md
+++ b/Payload-Obfuscation/README.md
@@ -1,0 +1,3 @@
+# Payload Obfuscation
+
+Techniques for disguising payload data. Each subfolder contains code for a specific type of obfuscation such as IP or MAC address manipulation.

--- a/Payload-Obfuscation/UUID-Obfuscation/README.md
+++ b/Payload-Obfuscation/UUID-Obfuscation/README.md
@@ -1,0 +1,3 @@
+# UUID Obfuscation
+
+Examples for obscuring and recovering UUID values.

--- a/Payload-Obfuscation/UUID-Obfuscation/UUIDDeobfuscation/README.md
+++ b/Payload-Obfuscation/UUID-Obfuscation/UUIDDeobfuscation/README.md
@@ -1,0 +1,3 @@
+# UUID Deobfuscation
+
+Reverses the encoding used in `UUIDFuscation`.

--- a/Payload-Obfuscation/UUID-Obfuscation/UUIDFuscation/README.md
+++ b/Payload-Obfuscation/UUID-Obfuscation/UUIDFuscation/README.md
@@ -1,0 +1,3 @@
+# UUID Obfuscation
+
+Shows how to encode a UUID so it does not look like the original.

--- a/Payload-Placement/README.md
+++ b/Payload-Placement/README.md
@@ -1,0 +1,6 @@
+# Payload Placement
+
+Examples showing how to embed a payload into various PE sections. Each subdirectory demonstrates placing shellcode in a different section.
+
+- `dot_data_section` – place shellcode in the .data section.
+- `dot_rdata_section` – place shellcode in the .rdata section.

--- a/Payload-Placement/dot_data_section/README.md
+++ b/Payload-Placement/dot_data_section/README.md
@@ -1,0 +1,3 @@
+# .data Section
+
+Example of storing shellcode in the `.data` section of a PE. Build with `zig build` to generate the example binary.

--- a/Payload-Placement/dot_rdata_section/README.md
+++ b/Payload-Placement/dot_rdata_section/README.md
@@ -1,0 +1,3 @@
+# .rdata Section
+
+Places shellcode in the `.rdata` section so it remains read-only at load time. Compile with `zig build`.


### PR DESCRIPTION
## Summary
- add README files for payload placement examples
- document AES subdirectories and encryption methods
- add documentation for RC4 and XOR examples
- explain IP, MAC, and UUID obfuscation examples
- create READMEs for deobfuscation counterparts

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684126dc37fc83209f27fc062af43cbf