### PR TITLE
Fix documentation links for code examples

### DIFF
--- a/src/Malware-Techniques/Payload-Staging/web_server.md
+++ b/src/Malware-Techniques/Payload-Staging/web_server.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Staging/web_server)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Payload-Staging/web_server)
 
 ## Code Walkthrough
 

--- a/src/Malware-Techniques/Payload-Staging/windows_registry.md
+++ b/src/Malware-Techniques/Payload-Staging/windows_registry.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Staging/windows_registry)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Payload-Staging/windows_registry)
 
 ## Code Walkthrough
 

--- a/src/Malware-Techniques/Process-Enumeration/create_tool_help_32_snapshot.md
+++ b/src/Malware-Techniques/Process-Enumeration/create_tool_help_32_snapshot.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Process-Enumeration/create_tool_help_32_snapshot)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Process-Enumeration/create_tool_help_32_snapshot)
 
 ## Code Walkthrough
 

--- a/src/Malware-Techniques/Process-Enumeration/enum_processes.md
+++ b/src/Malware-Techniques/Process-Enumeration/enum_processes.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Process-Enumeration/enum_processes)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Process-Enumeration/enum_processes)
 
 ## Code Walkthrough
 

--- a/src/Malware-Techniques/Process-Enumeration/nt_query_system_information.md
+++ b/src/Malware-Techniques/Process-Enumeration/nt_query_system_information.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Process-Enumeration/nt_query_system_information)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Process-Enumeration/nt_query_system_information)
 
 ## Code Walkthrough
 

--- a/src/Malware-Techniques/Process-Injection/dll_injection.md
+++ b/src/Malware-Techniques/Process-Injection/dll_injection.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Process-Injection/dll_injection)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Process-Injection/dll_injection)
 
 ## Code Walkthrough
 

--- a/src/Malware-Techniques/Process-Injection/shellcode_injection.md
+++ b/src/Malware-Techniques/Process-Injection/shellcode_injection.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Process-Injection/shellcode_injection)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Process-Injection/shellcode_injection)
 
 ## Code Walkthrough
 

--- a/src/Malware-Techniques/Thread-Hijacking/local_thread_creation.md
+++ b/src/Malware-Techniques/Thread-Hijacking/local_thread_creation.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Thread-Hijacking/local_thread_creation/)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Thread-Hijacking/local_thread_creation/)
 
 ## Code Walkthrough
 

--- a/src/Payload-Encryption/AES.md
+++ b/src/Payload-Encryption/AES.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/Payload-Encryption/AES)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Encryption/AES)
 
 ## Using bcrypt.h
 

--- a/src/Payload-Encryption/RC4.md
+++ b/src/Payload-Encryption/RC4.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/Payload-Encryption/RC4)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Encryption/RC4)
 
 ## Using SystemFunction032
 

--- a/src/Payload-Encryption/XOR.md
+++ b/src/Payload-Encryption/XOR.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/Payload-Encryption)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Encryption/XOR)
 
 ## Using Standard Library
 

--- a/src/Payload-Execution/dll.md
+++ b/src/Payload-Execution/dll.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/Payload-Execution/dll)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Execution/dll)
 
 ## Code Walkthrough
 

--- a/src/Payload-Execution/shellcode.md
+++ b/src/Payload-Execution/shellcode.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/Payload-Execution/shellcode)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Execution/shellcode)
 
 ## Code Walkthrough
 

--- a/src/Payload-Obfuscation/IP-Address-Obfuscation.md
+++ b/src/Payload-Obfuscation/IP-Address-Obfuscation.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/Payload-Obfuscation/IP-Address-Obfuscation)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Obfuscation/IP-Address-Obfuscation)
 
 ## Intro
 

--- a/src/Payload-Obfuscation/MAC-Address-Obfuscation.md
+++ b/src/Payload-Obfuscation/MAC-Address-Obfuscation.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/Payload-Obfuscation/MAC-Address-Obfuscation)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Obfuscation/MAC-Address-Obfuscation)
 
 ## Obfuscation
 

--- a/src/Payload-Obfuscation/UUID-Obfuscation.md
+++ b/src/Payload-Obfuscation/UUID-Obfuscation.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/Payload-Obfuscation/UUID-Obfuscation)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Obfuscation/UUID-Obfuscation)
 
 ## Obfuscation
 

--- a/src/Payload-Placement/dot_data.md
+++ b/src/Payload-Placement/dot_data.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/Payload-Placement/dot_data_section)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Placement/dot_data_section)
 
 ## What Is Payload?
 

--- a/src/Payload-Placement/dot_rdata.md
+++ b/src/Payload-Placement/dot_rdata.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/Payload-Placement/dot_rdata_section)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Placement/dot_rdata_section)
 
 ## Code Walkthrough
 

--- a/src/Payload-Placement/dot_text.md
+++ b/src/Payload-Placement/dot_text.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/Payload-Placement/dot_text_section)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Placement/dot_text_section)
 
 ## Code Walkthrough
 

--- a/src/Reverse-Shell/std_reverse_shell.md
+++ b/src/Reverse-Shell/std_reverse_shell.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/Reverse-Shell/std_reverse_shell)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Reverse-Shell/std_reverse_shell)
 
 ## Code Walkthrough
 


### PR DESCRIPTION
## Summary
- ensure all "See the code example" links point to correct locations in the repo

## Testing
- `./build_all.sh` *(fails: `zig` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dee9eba8c8320af586ec4ff192182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated code example links in the "TL;DR" sections of various documentation files to point to the correct locations within the repository. No other content or functionality was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->