### PR TITLE
Fix TL;DR source links

### DIFF
--- a/src/Advanced-Malware-Techniques/Callback-Code-Execution/callback_code_execution.md
+++ b/src/Advanced-Malware-Techniques/Callback-Code-Execution/callback_code_execution.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Callback-Code-Execution)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Advanced-Malware-Techniques/Callback-Code-Execution)
 
 Callback code execution is a technique that leverages Windows API functions that accept callback function pointers to execute shellcode. Instead of using traditional methods like CreateThread or VirtualAlloc, this approach casts shellcode as a legitimate callback function, making it appear more benign to security solutions.
 

--- a/src/Advanced-Malware-Techniques/Payload-Staging/web_server.md
+++ b/src/Advanced-Malware-Techniques/Payload-Staging/web_server.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Payload-Staging/web_server)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Advanced-Malware-Techniques/Payload-Staging/web_server)
 
 Payload staging via web server downloads the malicious code from a remote
 location when the program executes. By keeping the payload off disk until it is

--- a/src/Advanced-Malware-Techniques/Payload-Staging/windows_registry.md
+++ b/src/Advanced-Malware-Techniques/Payload-Staging/windows_registry.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Payload-Staging/windows_registry)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Advanced-Malware-Techniques/Payload-Staging/windows_registry)
 Another staging mechanism is to hide the payload inside the Windows Registry.
 Malware can write encrypted shellcode to a registry value and later read it back
 when execution is desired. Because registry entries are less scrutinized than

--- a/src/Advanced-Malware-Techniques/Process-Enumeration/create_tool_help_32_snapshot.md
+++ b/src/Advanced-Malware-Techniques/Process-Enumeration/create_tool_help_32_snapshot.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Process-Enumeration/create_tool_help_32_snapshot)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Advanced-Malware-Techniques/Process-Enumeration/create_tool_help_32_snapshot)
 
 `CreateToolhelp32Snapshot` allows us to capture a snapshot of the system's
 process list. By iterating through this snapshot with `Process32First` and

--- a/src/Advanced-Malware-Techniques/Process-Enumeration/enum_processes.md
+++ b/src/Advanced-Malware-Techniques/Process-Enumeration/enum_processes.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Process-Enumeration/enum_processes)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Advanced-Malware-Techniques/Process-Enumeration/enum_processes)
 
 The `EnumProcesses` API from PSAPI retrieves an array of process identifiers for
 all running processes. By iterating over these IDs and opening each process, we

--- a/src/Advanced-Malware-Techniques/Process-Enumeration/nt_query_system_information.md
+++ b/src/Advanced-Malware-Techniques/Process-Enumeration/nt_query_system_information.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Process-Enumeration/nt_query_system_information)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Advanced-Malware-Techniques/Process-Enumeration/nt_query_system_information)
 
 `NtQuerySystemInformation` is a native function exported by `ntdll.dll` that can
 return extensive system data, including the list of running processes. Because

--- a/src/Advanced-Malware-Techniques/Process-Injection/APC-Injection/classic_apc_injection.md
+++ b/src/Advanced-Malware-Techniques/Process-Injection/APC-Injection/classic_apc_injection.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/APC-Injection/apc_injection)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Advanced-Malware-Techniques/Process-Injection/APC-Injection/apc_injection)
 
 APC injection is a stealthy code injection technique that executes malicious payloads within legitimate Windows thread contexts. It leverages the built-in APC mechanism via `QueueUserAPC` to schedule shellcode execution without creating new processes, making detection difficult.
 

--- a/src/Advanced-Malware-Techniques/Process-Injection/APC-Injection/early_bird_apc_injection.md
+++ b/src/Advanced-Malware-Techniques/Process-Injection/APC-Injection/early_bird_apc_injection.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/APC-Injection/early_bird_apc_injection)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Advanced-Malware-Techniques/Process-Injection/APC-Injection/early_bird_apc_injection)
 
 Early Bird APC injection is an advanced code injection technique that leverages the process creation lifecycle to execute malicious payloads before the main thread begins execution. This method creates a target process in a suspended or debugged state, injects shellcode, queues an APC to the main thread, and then resumes execution - causing the APC to execute immediately upon process startup.
 

--- a/src/Advanced-Malware-Techniques/Process-Injection/Thread-Hijacking/local_thread_creation.md
+++ b/src/Advanced-Malware-Techniques/Process-Injection/Thread-Hijacking/local_thread_creation.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Thread-Hijacking/local_thread_creation/)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Advanced-Malware-Techniques/Process-Injection/Thread-Hijacking/local_thread_creation/)
 
 Local thread creation is a stealthy way to run shellcode within the context of
 the current process. Instead of launching an entirely new program, the malware

--- a/src/Advanced-Malware-Techniques/Process-Injection/Thread-Hijacking/local_thread_enumeration.md
+++ b/src/Advanced-Malware-Techniques/Process-Injection/Thread-Hijacking/local_thread_enumeration.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Thread-Hijacking/local_thread_enumeration/)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Advanced-Malware-Techniques/Process-Injection/Thread-Hijacking/local_thread_enumeration/)
 
 This sample enumerates all threads running in the current process and hijacks one of them to execute the shellcode. Because a minimal Zig program only starts a single main thread, the code first spawns a dummy **worker thread** that simply sleeps in an infinite loop. Enumeration via `CreateToolhelp32Snapshot` then locates this worker so we can safely open its handle and modify its context. The C version of this technique usually finds other threads already present, so no extra thread is needed.
 

--- a/src/Advanced-Malware-Techniques/Process-Injection/Thread-Hijacking/remote_thread_creation.md
+++ b/src/Advanced-Malware-Techniques/Process-Injection/Thread-Hijacking/remote_thread_creation.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Thread-Hijacking/remote_thread_creation/)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Advanced-Malware-Techniques/Process-Injection/Thread-Hijacking/remote_thread_creation/)
 
 Remote thread creation in this context refers to injecting shellcode into a thread of a remote process. Rather than creating a new thread with `CreateRemoteThread`, this technique creates a suspended remote process using `CreateProcessA` with `CREATE_SUSPENDED`, then uses `GetThreadContext`, `SetThreadContext`, and `ResumeThread` to hijack and redirect execution of its main thread to injected shellcode. This method is stealthier than traditional remote thread creation because it avoids APIs typically monitored by security software (`CreateRemoteThread` in this case).
 

--- a/src/Advanced-Malware-Techniques/Process-Injection/Thread-Hijacking/remote_thread_enumeration.md
+++ b/src/Advanced-Malware-Techniques/Process-Injection/Thread-Hijacking/remote_thread_enumeration.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Thread-Hijacking/remote_thread_enumeration/)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Advanced-Malware-Techniques/Process-Injection/Thread-Hijacking/remote_thread_enumeration/)
 
 This sample enumerates threads in a remote target process and hijacks one to execute shellcode. The code uses `CreateToolhelp32Snapshot` to discover processes by name, then enumerates threads within the remote target process to find an accessible one.
 

--- a/src/Advanced-Malware-Techniques/Process-Injection/dll_injection.md
+++ b/src/Advanced-Malware-Techniques/Process-Injection/dll_injection.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Process-Injection/dll_injection)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Advanced-Malware-Techniques/Process-Injection/dll_injection)
 
 DLL injection forces a target process to load an external dynamic library. By
 allocating space for the DLL path and invoking `LoadLibrary` via a remote thread,

--- a/src/Advanced-Malware-Techniques/Process-Injection/shellcode_injection.md
+++ b/src/Advanced-Malware-Techniques/Process-Injection/shellcode_injection.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Techniques/Process-Injection/shellcode_injection)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Advanced-Malware-Techniques/Process-Injection/shellcode_injection)
 
 Shellcode injection writes raw machine code into the memory of another process
 and then executes it. Typically the attacker opens the target process with the

--- a/src/Basic-Payload-Management/Payload-Encryption/AES.md
+++ b/src/Basic-Payload-Management/Payload-Encryption/AES.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Encryption/AES)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Basic-Payload-Management/Payload-Encryption/AES)
 
 Advanced Encryption Standard (AES) is a widely used symmetric cipher. Malware
 often encrypts embedded payloads with AES so that static scanners cannot easily

--- a/src/Basic-Payload-Management/Payload-Encryption/RC4.md
+++ b/src/Basic-Payload-Management/Payload-Encryption/RC4.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Encryption/RC4)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Basic-Payload-Management/Payload-Encryption/RC4)
 
 RC4 is a simple stream cipher that remains popular in malicious code because of
 its small footprint and ease of implementation. In Windows, the undocumented

--- a/src/Basic-Payload-Management/Payload-Encryption/XOR.md
+++ b/src/Basic-Payload-Management/Payload-Encryption/XOR.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Encryption/XOR)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Basic-Payload-Management/Payload-Encryption/XOR)
 
 Exclusive OR (XOR) encryption is one of the simplest ways to obfuscate data.
 Each byte of the payload is XORed with a key value. Applying the same operation

--- a/src/Basic-Payload-Management/Payload-Execution/dll.md
+++ b/src/Basic-Payload-Management/Payload-Execution/dll.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Execution/dll)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Basic-Payload-Management/Payload-Execution/dll)
 
 Instead of embedding shellcode directly, malware can bundle its functionality in
 a DLL and rely on a small loader to execute it. The loader locates the DLL at

--- a/src/Basic-Payload-Management/Payload-Execution/shellcode.md
+++ b/src/Basic-Payload-Management/Payload-Execution/shellcode.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Execution/shellcode)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Basic-Payload-Management/Payload-Execution/shellcode)
 
 Executing payloads as shellcode involves storing the machine code directly in a
 buffer, allocating executable memory, and then jumping to that buffer. The code

--- a/src/Basic-Payload-Management/Payload-Obfuscation/IP-Address-Obfuscation.md
+++ b/src/Basic-Payload-Management/Payload-Obfuscation/IP-Address-Obfuscation.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Obfuscation/IP-Address-Obfuscation)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Basic-Payload-Management/Payload-Obfuscation/IP-Address-Obfuscation)
 
 IP address obfuscation disguises shellcode bytes as seemingly harmless IP
 strings. Each byte is translated into a portion of an IPv4 or IPv6 address,

--- a/src/Basic-Payload-Management/Payload-Obfuscation/MAC-Address-Obfuscation.md
+++ b/src/Basic-Payload-Management/Payload-Obfuscation/MAC-Address-Obfuscation.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Obfuscation/MAC-Address-Obfuscation)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Basic-Payload-Management/Payload-Obfuscation/MAC-Address-Obfuscation)
 
 MAC address obfuscation converts shellcode into strings formatted like hardware
 MAC addresses (e.g., `AA-BB-CC-DD-EE-FF`). Because such strings are common in

--- a/src/Basic-Payload-Management/Payload-Obfuscation/UUID-Obfuscation.md
+++ b/src/Basic-Payload-Management/Payload-Obfuscation/UUID-Obfuscation.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Obfuscation/UUID-Obfuscation)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Basic-Payload-Management/Payload-Obfuscation/UUID-Obfuscation)
 
 UUID obfuscation stores shellcode chunks as Universally Unique Identifier
 strings. Since UUIDs are routinely seen in configuration files and logs, a list

--- a/src/Basic-Payload-Management/Payload-Placement/dot_data.md
+++ b/src/Basic-Payload-Management/Payload-Placement/dot_data.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Placement/dot_data_section)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Basic-Payload-Management/Payload-Placement/dot_data_section)
 
 The `.data` section contains global variables that are readable and writable.
 Placing shellcode here is the simplest approach—declare a mutable array with the

--- a/src/Basic-Payload-Management/Payload-Placement/dot_rdata.md
+++ b/src/Basic-Payload-Management/Payload-Placement/dot_rdata.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Placement/dot_rdata_section)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Basic-Payload-Management/Payload-Placement/dot_rdata_section)
 
 The `.rdata` section holds read‑only data such as constants and string literals.
 By marking the payload as `const`, which will make it read-only, we can store shellcode

--- a/src/Basic-Payload-Management/Payload-Placement/dot_text.md
+++ b/src/Basic-Payload-Management/Payload-Placement/dot_text.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Payload-Placement/dot_text_section)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Basic-Payload-Management/Payload-Placement/dot_text_section)
 
 Placing a payload in the `.text` section hides it among the program's executable
 instructions. Because this section is typically marked read-only and executable,

--- a/src/Malware-Examples/Reverse-Shell/std_reverse_shell.md
+++ b/src/Malware-Examples/Reverse-Shell/std_reverse_shell.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Reverse-Shell/std_reverse_shell)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Examples/Reverse-Shell/std_reverse_shell)
 
 This example implements a classic reverse shell **using only Zig's standard
 library**. It connects to a remote host and spawns a command interpreter whose

--- a/src/Malware-Examples/Reverse-Shell/std_reverse_shell_with_tls.md
+++ b/src/Malware-Examples/Reverse-Shell/std_reverse_shell_with_tls.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Reverse-Shell/std_reverse_shell_with_tls)
+[See the code example](https://github.com/CX330Blake/Black-Hat-Zig/tree/main/src/Malware-Examples/Reverse-Shell/std_reverse_shell_with_tls)
 
 This example implements a classic reverse shell **using only Zig's standard library**.  
 Unlike the [previous one](../std_reverse_shell), this version **implements TLS encryption**, so all network traffic is encrypted. In real-world operations, antivirus and EDR solutions often monitor network traffic. If they detect something resembling command-and-control behavior, it may trigger an alert — which is exactly what we want to avoid. With this reverse shell, encrypted traffic helps **bypass basic detections** by obscuring the communication.


### PR DESCRIPTION
## Summary
- update TL;DR links to match current folder structure

## Testing
- `./build_all.sh` *(fails: `zig` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643daf5f348320a5307a59a1a7217f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated hyperlinks in the TL;DR sections of various documentation files to point to the correct directories for code examples. No other content or functionality was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->